### PR TITLE
support for the Amber model, including checkpoints

### DIFF
--- a/transformer_lens/loading_from_pretrained.py
+++ b/transformer_lens/loading_from_pretrained.py
@@ -225,6 +225,7 @@ OFFICIAL_MODEL_NAMES = [
     "google-t5/t5-base",
     "google-t5/t5-large",
     "ai-forever/mGPT",
+    "LLM360/Amber",
 ]
 """Official model names for models on HuggingFace."""
 
@@ -1531,6 +1532,8 @@ PYTHIA_CHECKPOINTS = [0, 1, 2, 4, 8, 16, 32, 64, 128, 256, 512] + list(
 # Pythia V1 has log-spaced early checkpoints (see line above), but V0 doesn't
 PYTHIA_V0_CHECKPOINTS = list(range(1000, 143000 + 1, 1000))
 
+# The steps for which there are checkpoints in the LLM360/Amber model
+AMBER_CHECKPOINTS = [f"{i:03}" for i in range(0, 359)]
 
 def get_checkpoint_labels(model_name: str, **kwargs):
     """Returns the checkpoint labels for a given model, and the label_type
@@ -1562,6 +1565,8 @@ def get_checkpoint_labels(model_name: str, **kwargs):
         else:
             label_type = "step"
         return labels, label_type
+    elif official_model_name.startswith("LLM360/Amber"):
+        return AMBER_CHECKPOINTS, "ckpt_"
     else:
         raise ValueError(f"Model {official_model_name} is not checkpointed.")
 
@@ -1641,6 +1646,14 @@ def get_pretrained_state_dict(
                 hf_model = AutoModelForCausalLM.from_pretrained(
                     official_model_name,
                     revision=f"step{cfg.checkpoint_value}",
+                    torch_dtype=dtype,
+                    token=huggingface_token,
+                    **kwargs,
+                )
+            elif official_model_name.startswith("LLM360/Amber"):
+                hf_model = AutoModelForCausalLM.from_pretrained(
+                    official_model_name,
+                    revision=f"ckpt_{cfg.checkpoint_value}",
                     torch_dtype=dtype,
                     token=huggingface_token,
                     **kwargs,


### PR DESCRIPTION
<!--
When opening your PR, please make sure to only request a merge to `main` when you have found a bug in the currently released version of TransformerLens. All other PRs should go to `dev` in order to keep the docs in sync with the currently released version.

Please also make sure the branch you are attempting to merge from is not named `main`, or `dev`. Branches with these names from a different remote cause conflicting name issues when we periodically attempt to bring your PR up to date with the current stable TransformerLens source.

If your PR is primarily affecting docs, make sure has the string "docs" in its name. Building docs is disabled by default to avoid CI time, but the job has been configured to run whenever a branch with the word "docs" in it is being merged.
-->
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Screenshots
Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |


To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have not rewritten tests relating to key interfaces which would affect backward compatibility

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->